### PR TITLE
:zap: Feat:data.Price Count 및 배치

### DIFF
--- a/src/components/detail/ProductDetailSection.js
+++ b/src/components/detail/ProductDetailSection.js
@@ -6,13 +6,17 @@ import SizeSelect from "./SizeSelect";
 import TotalPaymentAmount from "./TotalPaymentAmount";
 
 const ProductDetailSection = ({ data }) => {
+  //Info에 들어갈 데이터 Price 가공
+  const cost = data.Price;
+  const discountPercentage = data.Percentage;
+
   return (
     <>
       <ProductImgContainer>
         <ProductImage data={data} />
       </ProductImgContainer>
       <ProductDescription>
-        <ProductInfo />
+        <ProductInfo cost={cost} discountPercentage={discountPercentage} />
         <ProductReviewSale />
         <SizeAmountContainer>
           <SizeSelect />

--- a/src/components/detail/ProductInfo.js
+++ b/src/components/detail/ProductInfo.js
@@ -2,7 +2,13 @@ import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { styled } from "styled-components";
 
-const ProductInfo = () => {
+const ProductInfo = ({ cost, discountPercentage }) => {
+  const disCountPrice = cost - (cost * discountPercentage) / 100;
+
+  //쿠폰 할인하면 정수값이 76755원 나와서 7675.5 까지 소수점 옮겨서 소수점 아래 숫자들은 floor로 날려버리기
+  const CouponPrice =
+    Math.floor((disCountPrice - (disCountPrice * 15) / 100) / 10) * 10;
+
   return (
     <>
       <ProductInfoContainer>
@@ -16,17 +22,25 @@ const ProductInfo = () => {
         <ProductName>
           <h2>베어 자수 케일리 스커프 털 슬리퍼 / RFS11478W</h2>
         </ProductName>
-        <div className="detail-sale">
+        <DisCountcontainer>
           <div>
-            <span>89,000원</span>
-            <span>31%</span>
-            <span>129,000원</span>
+            <span style={{ fontWeight: "bold", fontSize: "18px" }}>
+              {disCountPrice}원
+            </span>
+            <span style={{ fontWeight: "bold", color: "red" }}>
+              {discountPercentage}%
+            </span>
+            <span style={{ textDecoration: "line-through" }}>{cost}원</span>
           </div>
           <div>
-            <span>신규회원 가입 15% 쿠폰 적용가</span>
-            <span>75,650원</span>
+            <span style={{ marginRight: "10px" }}>
+              신규회원 가입 15% 쿠폰 적용가
+            </span>
+            <span style={{ fontWeight: "bold", fontSize: "18px" }}>
+              {CouponPrice}원
+            </span>
           </div>
-        </div>
+        </DisCountcontainer>
       </ProductInfoContainer>
     </>
   );
@@ -50,4 +64,10 @@ const BrandLogoContainer = styled.div`
 
 const ProductName = styled.div`
   margin-top: 15px;
+`;
+
+const DisCountcontainer = styled.div`
+  & div:first-child span {
+    margin-right: 10px;
+  }
 `;

--- a/src/pages/Detail.js
+++ b/src/pages/Detail.js
@@ -15,6 +15,7 @@ const Detail = () => {
     Name: "베어 자수 케일리 스커프 털 슬리퍼",
     Code: "RFS11478W",
     Price: 129000,
+    Percentage: 30,
     Size: [220, 225, 230, 235, 240, 245, 250],
     Imgs: [
       process.env.PUBLIC_URL + `/Images/shoes1.jpg`,
@@ -22,6 +23,9 @@ const Detail = () => {
       process.env.PUBLIC_URL + `/Images/shoes3.jpg`,
     ],
   };
+
+  //check
+  // console.log("여기요", isNaN(product.sale));
 
   useEffect(() => {
     setData(product);


### PR DESCRIPTION
* Related to #10

## 설명
목데이터의 price 계산 하여 배치


## 기타 사항
* 원가, 할인 가격, 할인 + 쿠폰 가격 3가지 배치
* 숫자 자릿수 내림
   쿠폰 할인하면 정수값이 76755원 나와서 7675.5 까지 소수점 옮겨서 소수점 아래 숫자들은 floor로 날려버리기
```
const CouponPrice =
    Math.floor((disCountPrice - (disCountPrice * 15) / 100) / 10) * 10;
```